### PR TITLE
feat: Shift from ABC to Protocol where appropriate

### DIFF
--- a/src/openapi_service_client/config/auth_strategy.py
+++ b/src/openapi_service_client/config/auth_strategy.py
@@ -1,9 +1,8 @@
-from abc import ABC, abstractmethod
-from typing import Any, Dict
+from typing import Any, Dict, Protocol, runtime_checkable
 
 
-class AuthenticationStrategy(ABC):
-    @abstractmethod
+@runtime_checkable
+class AuthenticationStrategy(Protocol):
     def apply_auth(self, security_scheme: Dict[str, Any], request: Dict[str, Any]):
         pass
 

--- a/src/openapi_service_client/http_client/client.py
+++ b/src/openapi_service_client/http_client/client.py
@@ -1,5 +1,4 @@
-from abc import ABC, abstractmethod
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Protocol
 
 import requests
 
@@ -17,8 +16,7 @@ VALID_HTTP_METHODS = [
 ]
 
 
-class AbstractHttpClient(ABC):
-    @abstractmethod
+class AbstractHttpClient(Protocol):
     def send_request(self, request: Dict[str, Any]) -> Any:
         pass
 


### PR DESCRIPTION
### Why:

This revision aims to improve readability and maintainability by replacing abstract base classes (ABC) with Protocols from the `typing` module. This change aligns the code with the latest Python best practices, simplifying the logic and making it more explicit to users.

### What:

The update changes the type signatures of the `AuthenticationStrategy` class in `src/openapi_service_client/config/auth_strategy.py` and the `AbstractHttpClient` in `src/openapi_service_client/http_client/client.py` from `ABC` to `Protocol`. This modification conveys that these objects are primarily used as type hints, enhancing the comprehensibility and maintainability of the code.

### How can it be used:

The new Protocol classes work similarly to the dropped ABCs. Users can provide their implementations that satisfy the `AuthenticationStrategy` and `AbstractHttpClient` protocols as required.

### How did you test it:

The changes were validated using numerous unit and integration tests covering various scenarios and use-cases involving the `AuthenticationStrategy` and `AbstractHttpClient`. All tests passed successfully, confirming that the revised implementation behaves as expected and maintains the original functionality. Additionally, mypy type checker was also used, and no type-related issues were found.

### Notes for the reviewer:
None