### PR TITLE
feat: Enable LLM plug-and-play, adjust OpenAI fn definition creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ OpenAPI Service Client is a Python library that enables effortless integration b
 
 The OpenAPI Service Client library aims to simplify the process of invoking OpenAPI-defined services using function-calling payloads from various LLM providers. By abstracting away the complexities of making HTTP requests, handling authentication, preparing invocation payloads, and processing responses, it allows users to easily invoke underlying services with LLM-generated function calls.
 
-The library supports multiple LLM providers, including OpenAI, Anthropic, and Cohere. Each LLM provider uses a unique function-calling schema definition format; OpenAPI Service Client abstracts these differences, enabling a uniform approach to service invocation. Additionally, the library provides a flexible and extensible architecture that allows users to add support for additional LLM providers and function-calling formats.
+The library works with several LLM providers, including OpenAI, Anthropic, and Cohere. It uses a common method, `config.get_tools_definitions()`, to manage each provider's unique way of defining function calls. Similarly, differences in how these providers output function calls are handled uniformly through the `LLMProvider` and its `FunctionPayloadExtractor`. Additionally, the library's flexible and extensible design allows users to easily add support for more LLM providers and function-calling formats.
 
 ## Features
 
-- **Seamless LLM Integration**: Easily integrate with LLM-generated function calls for various providers, including OpenAI, Anthropic, and Cohere.
+- **Plug-and-Play LLM Integration**: Easily integrate with LLM-generated function calls for various providers, including OpenAI, Anthropic, and Cohere.
 - **OpenAPI Compliance**: Automatically handle REST service invocations and support various authentication strategies (API key, HTTP authentication, OAuth2).
 - **Customizable and Extensible**: Offers flexible configuration options and an extensible architecture to accommodate additional LLM providers and function-calling formats.
 
@@ -51,21 +51,21 @@ config = (
     .build()
 )
 
-# Initialize the OpenAPIServiceClient with configuration
-serper_api = OpenAPIServiceClient(config)
-
-# Setup the OpenAI API client and send the chat message
+# Setup the OpenAI API client...
 client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
-tool_choice = config.get_tools_definitions()
+
+# and send the chat message to create a function-calling response completion
 response = client.chat.completions.create(
     model="gpt-3.5-turbo",
     messages=[{"role": "user", "content": "Do a google search: Who was Nikola Tesla?"}],
-    tools=[{"type": "function", "function": tool_choice[0]}],
-    tool_choice={"type": "function", "function": {"name": tool_choice[0]["name"]}},
+    tools=config.get_tools_definitions()
 )
 
+# Initialize the OpenAPIServiceClient with configuration
+serper_api = OpenAPIServiceClient(config)
+
 # Simply pass the LLM response and invoke the service
-# The function-calling payload is extracted and processed automatically
+# The LLM specific function-calling payload is extracted and processed automatically
 service_response = serper_api.invoke(response)
 print(service_response)
 ```
@@ -95,13 +95,10 @@ config = (
     .build()
 )
 
-# Initialize the OpenAPIServiceClient with configuration
-serper_api = OpenAPIServiceClient(config)
-
-# Setup the Anthropic API client and send the chat message
+# Setup the Anthropic API client
 client = anthropic.Anthropic(api_key=os.getenv("ANTHROPIC_API_KEY"))
 
-# Create a message request using the Anthropic API client
+# and send the chat message to create a function-calling response completion
 response = client.beta.tools.messages.create(
     model="claude-3-opus-20240229",
     max_tokens=1024,
@@ -109,8 +106,11 @@ response = client.beta.tools.messages.create(
     messages=[{"role": "user", "content": "Do a google search: Who was Nikola Tesla?"}],
 )
 
+# Initialize the OpenAPIServiceClient with configuration
+serper_api = OpenAPIServiceClient(config)
+
 # Simply pass the LLM response and invoke the service
-# The function-calling payload is extracted and processed automatically
+# The LLM specific function-calling payload is extracted and processed automatically
 service_response = serper_api.invoke(response)
 print(service_response)
 ```
@@ -139,13 +139,10 @@ config = (
     .build()
 )
 
-# Initialize the OpenAPIServiceClient with configuration
-serper_api = OpenAPIServiceClient(config)
-
-# Setup the Cohere client 
+# Setup the Cohere client...
 client = cohere.Client(api_key=os.getenv("COHERE_API_KEY"))
 
-# And send the chat message
+# and send the chat message to create a function-calling response completion
 response = client.chat(
     model="command-r",
     preamble="A preamble aka system prompt goes here.",
@@ -153,8 +150,12 @@ response = client.chat(
     message="Do a google search: Who was Nikola Tesla?",
 )
 
+# Initialize the OpenAPIServiceClient with configuration
+serper_api = OpenAPIServiceClient(config)
+
+
 # Simply pass the LLM response and invoke the service
-# The function-calling payload is extracted and processed automatically
+# The LLM specific function-calling payload is extracted and processed automatically
 service_response = serper_api.invoke(response)
 print(service_response)
 ```

--- a/tests/client/test_client_live_anthropic.py
+++ b/tests/client/test_client_live_anthropic.py
@@ -32,6 +32,13 @@ class TestClientLiveAnthropic:
         service_response = serper_api.invoke(response)
         assert "inventions" in str(service_response)
 
+        # make a few more requests to test the same tool
+        service_response = serper_api.invoke(response)
+        assert "Serbian" in str(service_response)
+
+        service_response = serper_api.invoke(response)
+        assert "American" in str(service_response)
+
     @pytest.mark.skipif("ANTHROPIC_API_KEY" not in os.environ, reason="ANTHROPIC_API_KEY not set")
     def test_github(self, test_files_path):
         builder = ClientConfigurationBuilder()

--- a/tests/client/test_client_live_cohere.py
+++ b/tests/client/test_client_live_cohere.py
@@ -46,6 +46,13 @@ class TestClientLiveCohere:
         service_response = serper_api.invoke(response)
         assert "inventions" in str(service_response)
 
+        # make a few more requests to test the same tool
+        service_response = serper_api.invoke(response)
+        assert "Serbian" in str(service_response)
+
+        service_response = serper_api.invoke(response)
+        assert "American" in str(service_response)
+
     @pytest.mark.skipif("COHERE_API_KEY" not in os.environ, reason="COHERE_API_KEY not set")
     def test_github(self, test_files_path):
         builder = ClientConfigurationBuilder()

--- a/tests/client/test_client_live_openai.py
+++ b/tests/client/test_client_live_openai.py
@@ -19,16 +19,21 @@ class TestClientLiveOpenAPI:
             .build()
         )
         client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
-        tool_choice = config.get_tools_definitions()
         response = client.chat.completions.create(
             model="gpt-3.5-turbo",
-            messages=[{"role": "user", "content": "Do a google search: Who was Nikola Tesla?"}],
-            tools=[{"type": "function", "function": tool_choice[0]}],
-            tool_choice={"type": "function", "function": {"name": tool_choice[0]["name"]}},
+            messages=[{"role": "user", "content": "Do a serperdev google search: Who was Nikola Tesla?"}],
+            tools=config.get_tools_definitions(),
         )
         serper_api = OpenAPIServiceClient(config)
         service_response = serper_api.invoke(response)
         assert "inventions" in str(service_response)
+
+        # make a few more requests to test the same tool
+        service_response = serper_api.invoke(response)
+        assert "Serbian" in str(service_response)
+
+        service_response = serper_api.invoke(response)
+        assert "American" in str(service_response)
 
     @pytest.mark.skipif("OPENAI_API_KEY" not in os.environ, reason="OPENAI_API_KEY not set")
     def test_github(self, test_files_path):
@@ -36,7 +41,6 @@ class TestClientLiveOpenAPI:
         config = builder.with_openapi_spec(test_files_path / "github_compare.yml").build()
 
         client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
-        tool_choice = config.get_tools_definitions()
         response = client.chat.completions.create(
             model="gpt-3.5-turbo",
             messages=[
@@ -46,8 +50,7 @@ class TestClientLiveOpenAPI:
                     " haystack and owner deepset-ai",
                 }
             ],
-            tools=[{"type": "function", "function": tool_choice[0]}],
-            tool_choice={"type": "function", "function": {"name": tool_choice[0]["name"]}},
+            tools=config.get_tools_definitions(),
         )
         serper_api = OpenAPIServiceClient(config)
         service_response = serper_api.invoke(response)


### PR DESCRIPTION
### Why:
Enhances the library by refactoring the code to manage LLM providers' unique function-calling schemas more effectively. The changes improve the uniformity of service invocation and provide a more flexible and extensible architecture for supporting additional LLM providers and function-calling formats.

### What:
The PR modifies the `README.md` file, updates the OpenAI provider in `openai.py`, and adds test cases for Anthropic, Cohere, and OpenAI LLM.s  The changes also refactor the `OpenAISchemaConverter` to apply transformations to function definitions.

### How can it be used:
The library now uses `config.get_tools_definitions()` to retrieve and utilize function definitions specific to each LLM provider directly. This approach ensures that functions specified in LLM chat completions are accurately reflected across all supported LLMs. Users can initialize the OpenAPIServiceClient with a provider's API key and seamlessly invoke services using responses from various LLM providers.

### How did it get tested:
The changes were tested using unit tests and integration tests with live LLM providers, including OpenAI, Anthropic, and Cohere. The tests validate the correct extraction and processing of function-calling payloads from the LLM responses.

### Notes for the reviewer:
Please review the updated `OpenAISchemaConverter` and the new test cases to ensure that the changes are correct and effective. The reviewer should also verify that the `OpenAPIServiceClient` can be used seamlessly with different LLM providers.